### PR TITLE
Remove deprecated str_after helper

### DIFF
--- a/tests/Unit/Scopes/OrWhereLikeTest.php
+++ b/tests/Unit/Scopes/OrWhereLikeTest.php
@@ -5,6 +5,7 @@ namespace AwesIO\Repository\Tests\Unit\Scopes;
 use AwesIO\Repository\Tests\TestCase;
 use AwesIO\Repository\Tests\Stubs\Model;
 use AwesIO\Repository\Scopes\Clauses\OrWhereLikeScope;
+use Illuminate\Support\Str;
 
 class OrWhereLikeTest extends TestCase
 {
@@ -19,7 +20,7 @@ class OrWhereLikeTest extends TestCase
 
         $results = $scope->scope(
             new Model, 
-            str_after($model->name, $model->name[0]),
+            Str::after($model->name, $model->name[0]),
             'name'
         )->get();
 
@@ -40,13 +41,13 @@ class OrWhereLikeTest extends TestCase
 
         $builder = $scope->scope(
             new Model, 
-            str_after($model1->name, $model1->name[0]),
+            Str::after($model1->name, $model1->name[0]),
             'name'
         );
 
         $results = $scope->scope(
             $builder, 
-            str_after($model2->name, $model2->name[0]),
+            Str::after($model2->name, $model2->name[0]),
             'name'
         )->get();
 

--- a/tests/Unit/Scopes/WhereLikeTest.php
+++ b/tests/Unit/Scopes/WhereLikeTest.php
@@ -5,6 +5,7 @@ namespace AwesIO\Repository\Tests\Unit\Scopes;
 use AwesIO\Repository\Tests\TestCase;
 use AwesIO\Repository\Tests\Stubs\Model;
 use AwesIO\Repository\Scopes\Clauses\WhereLikeScope;
+use Illuminate\Support\Str;
 
 class WhereLikeTest extends TestCase
 {
@@ -19,7 +20,7 @@ class WhereLikeTest extends TestCase
 
         $results = $scope->scope(
             new Model, 
-            str_after($model->name, $model->name[0]),
+            Str::after($model->name, $model->name[0]),
             'name'
         )->get();
 
@@ -40,7 +41,7 @@ class WhereLikeTest extends TestCase
 
         $builder = $scope->scope(
             new Model, 
-            str_after($model1->name, $model1->name[0]),
+            Str::after($model1->name, $model1->name[0]),
             'name'
         );
 


### PR DESCRIPTION

## Summary

<!-- Summary of the PR -->

the helper function is deprecated in Laravel 6.
#https://github.com/laravel/framework/pull/26898#issue-239566151

## Test plan (required)

I changed this in the test itself.

thank you.



